### PR TITLE
Remove redundant step from workflow example

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
 jobs:
   tests:
+    name: Test for release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ jobs:
             - name: Checkout Repository
               uses: actions/checkout@v4
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '20'
-
             - name: Validate Mod
               uses: TheBrutalX/factorio-mod-uploader-action@v1
               with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "factiorio-release-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "factiorio-release-action",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "factiorio-release-action",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "factiorio-release-action",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factiorio-release-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Automated process for automatic release factorio mod",
   "main": "dist/bundle.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factiorio-release-action",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Automated process for automatic release factorio mod",
   "main": "dist/bundle.js",
   "scripts": {


### PR DESCRIPTION
The workflow [runs fine without](https://github.com/pindab0ter/UPSFriendlyNixieTubeDisplay/actions/runs/12027387246) it as you can see in [this repo](https://github.com/pindab0ter/UPSFriendlyNixieTubeDisplay/blob/548d634da9b89b1e68cdc9dfaaa959c0712700d0/.github/workflows/publish.yml)