### PR TITLE
fix: don't create empty directories for ignored paths (#38)

### DIFF
--- a/src/__tests__/factorioIgnoreParser.test.ts
+++ b/src/__tests__/factorioIgnoreParser.test.ts
@@ -323,15 +323,15 @@ describe('FactorioIgnoreParser', () => {
             }
         });
 
-        it('should handle empty directories', async () => {
-            fs.readdir = jest.fn().mockResolvedValue([]);
+        it('should not create empty directories', async () => {
+            fs.readdir = jest.fn().mockResolvedValue(['file1.txt']);
             fs.mkdir = jest.fn().mockResolvedValue(undefined);
 
-            parser = new FactorioIgnoreParser('', false);
+            parser = new FactorioIgnoreParser('*.txt', false);
             const copiedFiles = await parser.copyNonIgnoredFiles('src', 'dest');
 
             expect(copiedFiles).toHaveLength(0);
-            expect(fs.mkdir).toHaveBeenCalledTimes(1);
+            expect(fs.mkdir).toHaveBeenCalledTimes(0);
         });
     });
 

--- a/src/services/FactorioIgnoreParser.ts
+++ b/src/services/FactorioIgnoreParser.ts
@@ -195,7 +195,7 @@ export class FactorioIgnoreParser {
     ): Promise<string[]> {
         const copiedFiles: string[] = new Array();
         const files = await fs.readdir(source);
-        await fs.mkdir(destination, { recursive: true });
+        let destinationDirCreated = false;
         for (const file of files) {
             const filePath = join(source, file);
             debug(`Processing file ${file} (${source}) to ${destination}`);
@@ -206,6 +206,10 @@ export class FactorioIgnoreParser {
                 copiedFiles.push(...copied);
             } else {
                 if (!this.shouldIgnore(filePath)) {
+                    if (!destinationDirCreated) {
+                        await fs.mkdir(destination, {recursive: true});
+                        destinationDirCreated = true;
+                    }
                     await fs.copyFile(filePath, destinationPath);
                     copiedFiles.push(filePath);
                     debug(`Copied file ${file} to ${destinationPath}`);


### PR DESCRIPTION
A proposed fix for issue https://github.com/TheBrutalX/Factorio-mod-uploader-action/issues/38.

I've implemented the "only create directory before copying a file" approach that I suggested, since it basically just required moving the `mkdir` line into the `!shouldIgnore` if block. I've used a variable to only run the `mkdir` once, which technically isn't necessary because it's not an error if the directory already exists, but seems a bit cleaner to me.

If you prefer the "clean up round" option, I could try to implement that as well, but this option seemed easier to me ^^

P.S.: I've run the tests and adjusted/replaced the "should handle empty directories" test. I also ran the action locally with `act` and verified that the empty directories are indeed not created anymore.