### PR TITLE
show error message

### DIFF
--- a/src/services/FactorioModPortalApiService/index.ts
+++ b/src/services/FactorioModPortalApiService/index.ts
@@ -1,4 +1,4 @@
-import { debug } from '@actions/core';
+import { debug, warning } from '@actions/core';
 import * as fmpe from '@errors/FactorioModPortalApiErrors';
 import { IModInfo } from '@interfaces/IFactorioModInfo';
 import axios, { AxiosError } from 'axios';
@@ -243,6 +243,7 @@ export default class FactorioModPortalApiService {
         if (!e.response.data) throw new fmpe.FactorioModPortalApiError('Unknown error', e.stack);
         const errorResponse = e.response.data as FactorioErrorResponse;
         if (!errorResponse.error) throw new fmpe.FactorioModPortalApiError('Missing error on body', e.stack);
+        if (errorResponse.message) warning(errorResponse.message);
         switch (errorResponse.error) {
             case 'InvalidApiKey':
                 throw new fmpe.FactorioModPortalApiInvalidApiTokenError(e.stack);


### PR DESCRIPTION
In case that mod portal rejects the upload, it is very helpful to see the reason why.  

Had the problem that my chosen mod name was too short (mod names need to have more than 3 chars, but AFAIK that isn't documented anywhere) and I had no idea, what might be wrong, until I made this small change.